### PR TITLE
chore(docs): add github fetch example to demo

### DIFF
--- a/preview/main.ts
+++ b/preview/main.ts
@@ -52,7 +52,6 @@ const terminal = initTerminal({
           })
           .then(data => {
             print(`${data.name ?? username} has ${data.public_repos} public repos`)
-            stop()
           })
           .catch((error) => {
             if (error.status === 404) {
@@ -60,8 +59,7 @@ const terminal = initTerminal({
             } else {
               print('We got an error talking to Github')
             }
-            stop()
-          })
+          }).finally(() => stop())
       }
     }
   }


### PR DESCRIPTION
## Description

Added a fetch example to the demo site. Type ```github mkrl``` and it returns ```Mikhail Korolev has 42 public repos```.
If you prefer me to do it with async await I can adjust it.

I'm not sure what to put in the feature list. Maybe something like"Block user input while you do an operation, like fetch data". We could make the clickable command be to your profile or some big org like ```github mozilla``` 

Based on #13 

## Pre-review checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if required)
- [X] My contribution is awesome
