### PR TITLE
fix(css): remove padding of input text

### DIFF
--- a/public/ttty.css
+++ b/public/ttty.css
@@ -23,6 +23,7 @@
     color: white;
     font-family: "Courier New", monospace;
     font-size: 16px;
+    padding: 0px;
 }
 .terminal-type > input:focus{
     border: none !important;


### PR DESCRIPTION
## Description

make input text aligned with past command texts by overriding default browser padding.

Fixes (#21) 

## Pre-review checklist:

- [x] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation (if required)
- [X] My contribution is awesome
